### PR TITLE
disabled-google-analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ def analysis(
 # Gradio UIの設定
 enables = {}
 sam_params = {}
-with gr.Blocks() as demo:
+with gr.Blocks(analytics_enabled=False, title="AMeThyst") as demo:
     with gr.Row() as common:
         with gr.Column() as sub:
             input=gr.Image(type="pil")


### PR DESCRIPTION
このPRは、２つの内容変更です。

１，Gradioは初期設定でGoogleアナリティクスを使用します。Googleアナリティクスの無効化(OFF)を行います。
該当のissue
https://github.com/gradio-app/gradio/issues/4226
ドキュメント BlocksのInitializationセクションのanalytics_enabled。
https://www.gradio.app/docs/gradio/blocks#initialization

２，ブラウザにアプリ名を表示します。
タブの視認性を良くするために変更しました。

お忙しいところ申し訳ないのですが、ご確認のほど宜しくお願い致します。